### PR TITLE
API proposal for notebook extensibility

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1527,17 +1527,13 @@ declare module 'vscode' {
 
 	export type CellOutput = CellStreamOutput | CellErrorOutput | CellDisplayOutput & { metadata: { [key: string]: any} }; // Metadata can be put here by an execution so that a renderer can use it
 
-	export interface NotebookExecutionInfo {
-		data: { [key: string]: any}
-	}
-
 	export interface NotebookCell {
 		readonly uri: Uri;
 		handle: number;
 		language: string;
 		cellKind: CellKind;
 		outputs: CellOutput[];
-		executionInfo: NotebookExecutionInfo;
+        	metadata: { [key: string]: any }
 		getContent(): string; // rchiodo: This seems weird? Why does this have methods on it?
 	}
 
@@ -1547,7 +1543,7 @@ declare module 'vscode' {
 		readonly isDirty: boolean;
 		languages: string[];
 		cells: NotebookCell[];
-		rootExecutionInfo: NotebookExecutionInfo;
+		metadata: { [key: string]: any }
 		displayOrder?: GlobPattern[];
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1533,8 +1533,9 @@ declare module 'vscode' {
 		language: string;
 		cellKind: CellKind;
 		outputs: CellOutput[];
-        metadata: { [key: string]: any }
-		getContent(): string; // rchiodo: This seems weird? Why does this have methods on it?
+		metadata: { [key: string]: any }
+		source: string;
+		getContent(): string; // rchiodo: This seems weird? Why does this have methods on it? Is this the source?
 	}
 
 	export interface NotebookDocument {

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1533,7 +1533,6 @@ declare module 'vscode' {
 		language: string;
 		cellKind: CellKind;
 		outputs: CellOutput[];
-		metadata: { [key: string]: any }
 		source: string;
 		getContent(): string; // rchiodo: This seems weird? Why does this have methods on it? Is this the source?
 	}
@@ -1549,7 +1548,6 @@ declare module 'vscode' {
 		readonly isDirty: boolean;
 		languages: string[];
 		cells: NotebookCell[];
-		metadata: { [key: string]: any }
 		executionInfo: NotebookExecutionInfo;
 		displayOrder?: GlobPattern[];
 	}

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1533,7 +1533,7 @@ declare module 'vscode' {
 		language: string;
 		cellKind: CellKind;
 		outputs: CellOutput[];
-        	metadata: { [key: string]: any }
+        metadata: { [key: string]: any }
 		getContent(): string; // rchiodo: This seems weird? Why does this have methods on it?
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1538,6 +1538,12 @@ declare module 'vscode' {
 		getContent(): string; // rchiodo: This seems weird? Why does this have methods on it? Is this the source?
 	}
 
+	export interface NotebookExecutionInfo {
+		name: string;
+		display_name: string;
+		metadata: { [key: string]: any }
+	}
+
 	export interface NotebookDocument {
 		readonly uri: Uri;
 		readonly fileName: string;
@@ -1545,6 +1551,7 @@ declare module 'vscode' {
 		languages: string[];
 		cells: NotebookCell[];
 		metadata: { [key: string]: any }
+		executionInfo: NotebookExecutionInfo;
 		displayOrder?: GlobPattern[];
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1540,7 +1540,6 @@ declare module 'vscode' {
 
 	export interface NotebookExecutionInfo {
 		name: string;
-		display_name: string;
 		metadata: { [key: string]: any }
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1595,7 +1595,11 @@ declare module 'vscode' {
 	 * Allows observing the execution of cells from a NotebookExecution
 	 */
 	export interface NotebookExecutionObserver {
-		onExecuteCell(document: NotebookDocument, cell: NotebookCell, eventProvider: NotebookCellExecutionResult): void;
+		onExecuteStart(document: NotebookDocument, cell: NotebookCell): void;
+		onCellOutput(document: NotebookDocument, cell: NotebookCell, outputs: CellOutput[]): void;
+		onCellClear(document: NotebookDocument, cell: NotebookCell, wait: boolean): void;
+		onDocumentOutput(document: NotebookDocument, cell: NotebookCell, outputs: CellOutput[]): void;
+		onExecuteComplete(document: NotebookDocument, cell: NotebookCell, executionCount: number): void;
 	}
 
 	export interface NotebookOutputSelector {


### PR DESCRIPTION
Draft proposal for extended extensibility for notebooks. For this item here:
https://github.com/microsoft/vscode-python/issues/10505

Bunch of stuff
1) Make cell outputs have extra data for correlation between execution and render providers. 
- **Use case**: Execution puts a special tag for the file name for the interactive window. This indicates to an NotebookOutputTransformer to add links into the error output.
2) Add execution information to a document and a cell (this would be the kernel to use). 
- **Use case**: Allows a kernel to be started with the correct information. Language isn't enough.
3) Split execution from NotebookDocument creation (at least I think the NotebookProducer translates ipynb files to NotebookDocument objects). 
- **Use case**: One extension translates documents, while multiple might provide just execution for ipynb files.
4) Make execution fire events as there are multiple stages of output. 
- **Use case**: Streaming data as it runs. Clearing data part way through.
5) Create a NotebookOutputTransformer extensibility point. 
- **Use case**: Modifying error to have line numbers and clicks. Modifying images to allow for opening in a plot viewer.
6) Create a NotebookExecutionObserver extensibility point.
- **Use case**: Variable explorer, gather. Allows for a separate kernel to be kept in sync.